### PR TITLE
Add ZenML observability integration

### DIFF
--- a/core/rag/__init__.py
+++ b/core/rag/__init__.py
@@ -1,0 +1,1 @@
+from .zenml_observability import ZenMLObservability

--- a/core/rag/zenml_observability.py
+++ b/core/rag/zenml_observability.py
@@ -1,0 +1,28 @@
+from typing import Any, Callable
+from datetime import datetime
+try:
+    from zenml.logger import get_logger
+except Exception:  # pragma: no cover - ZenML optional
+    get_logger = None
+
+class ZenMLObservability:
+    """Observability callbacks using ZenML logging."""
+
+    def __init__(self):
+        if get_logger is None:
+            raise ImportError("zenml is not installed")
+        self.logger = get_logger(__name__)
+
+    def rag_step_callback(self) -> Callable:
+        """Return a callback to log RAG steps to ZenML."""
+
+        def callback(step: str, input: Any, output: Any) -> None:
+            ts = datetime.now().isoformat()
+            self.logger.info(f"{ts} - step={step}")
+            self.logger.debug(f"input_type={type(input).__name__}")
+            if step == "retrieval":
+                count = len(output) if isinstance(output, list) else 0
+                self.logger.info(f"retrieved_documents={count}")
+            elif step == "generation":
+                self.logger.info(f"output_length={len(str(output))}")
+        return callback

--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ from core.llm.llm_client import LLMClient
 from core.rag.chain_builder import RAGChainBuilder
 from core.rag.rag_pipeline import RAGPipeline
 from core.rag.observability import RagObservability
+from core.rag.zenml_observability import ZenMLObservability
 from ui.state_manager import state_manager
 from fix_vector_store import verify_store_type
 
@@ -72,6 +73,14 @@ def initialize_application() -> Dict[str, Any]:
             rag_observability = RagObservability()
             components["rag_observability"] = rag_observability
             logger.debug("RAG observability initialized successfully")
+
+            # Attempt to initialize ZenML observability as an optional feature
+            try:
+                zenml_observability = ZenMLObservability()
+                components["zenml_observability"] = zenml_observability
+                logger.debug("ZenML observability initialized successfully")
+            except Exception as ze:
+                logger.warning(f"ZenML observability not available: {ze}")
         except Exception as e:
             logger.error(f"Error initializing RAG observability: {str(e)}", exc_info=True)
             errors.append(f"RAG observability initialization error: {str(e)}")
@@ -83,7 +92,13 @@ def initialize_application() -> Dict[str, Any]:
                 # Get observability callback if available
                 observability_callbacks = []
                 if "rag_observability" in components:
-                    observability_callbacks.append(components["rag_observability"].rag_step_callback())
+                    observability_callbacks.append(
+                        components["rag_observability"].rag_step_callback()
+                    )
+                if "zenml_observability" in components:
+                    observability_callbacks.append(
+                        components["zenml_observability"].rag_step_callback()
+                    )
                 
                 rag_pipeline = RAGPipeline(
                     llm=components["llm_client"],
@@ -151,7 +166,8 @@ def update_system_state(components: Dict[str, Any]):
             components["vector_store"]._index_exists()
         ),
         "chain_initialized": "rag_chain" in components,
-        "rag_observability_enabled": "rag_observability" in components
+        "rag_observability_enabled": "rag_observability" in components,
+        "zenml_observability_enabled": "zenml_observability" in components
     }
     
     state_manager.update_system_state(**system_state)

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ black>=23.3.0
 flake8>=6.0.0
 mypy>=1.3.0
 isort>=5.12.0
+zenml>=0.56.0

--- a/ui/state_manager.py
+++ b/ui/state_manager.py
@@ -329,7 +329,9 @@ class AppStateManager:
             "system_state": {
                 "chain_initialized": False,
                 "vector_store_initialized": False,
-                "llm_initialized": False
+                "llm_initialized": False,
+                "rag_observability_enabled": False,
+                "zenml_observability_enabled": False
             }
         }
         
@@ -518,7 +520,9 @@ class AppStateManager:
         return self.get("system_state", {
             "chain_initialized": False,
             "vector_store_initialized": False,
-            "llm_initialized": False
+            "llm_initialized": False,
+            "rag_observability_enabled": False,
+            "zenml_observability_enabled": False
         })
     
     def update_system_state(self, **kwargs) -> None:


### PR DESCRIPTION
## Summary
- integrate optional ZenML-based observability
- log zenml step information alongside existing logging
- track zenml observability state
- include zenml in requirements

## Testing
- `python -m py_compile $(git ls-files '*.py')`